### PR TITLE
Blender 5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+all: linux macos windows
+
+linux: linux_x86_64
+
+linux_x86_64:
+	pip download -r requirements.txt --dest ./wheels --only-binary=:all: --python-version=3.13 --platform=manylinux_2_17_x86_64
+
+macos: macos_arm64 macos_x86_64
+
+macos_arm64:
+	pip download -r requirements.txt --dest ./wheels --only-binary=:all: --python-version=3.13 --platform=macosx_11_0_arm64
+
+macos_x86_64:
+	pip download -r requirements.txt --dest ./wheels --only-binary=:all: --python-version=3.13 --platform=macosx_11_0_x86_64
+
+windows: windows_amd64
+
+windows_amd64:
+	pip download -r requirements.txt --dest ./wheels --only-binary=:all: --python-version=3.13 --platform=win_amd64

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -8,7 +8,7 @@ maintainer = "Anton Florey <anton.florey@googlemail.com>"
 type = "add-on"
 website = "https://github.com/AntonFlorey/PolyZamboni"
 tags = ["3D View", "Import-Export"]
-blender_version_min = "4.2.0"
+blender_version_min = "5.1.0"
 
 license = [
   "SPDX:GPL-3.0-or-later",
@@ -20,29 +20,36 @@ platforms = ["windows-x64", "macos-arm64", "linux-x64", "macos-x64"]
 # 3rd party Python modules.
 # https://docs.blender.org/manual/en/dev/advanced/extensions/python_wheels.html
 wheels = [
-  "./wheels/networkx-3.4.2-py3-none-any.whl",
-  "./wheels/packaging-24.2-py3-none-any.whl",
-  "./wheels/cycler-0.12.1-py3-none-any.whl",
-  "./wheels/pyparsing-3.2.1-py3-none-any.whl",
-  "./wheels/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
-  "./wheels/six-1.17.0-py2.py3-none-any.whl",
-  "./wheels/fonttools-4.57.0-py3-none-any.whl",
-  "./wheels/matplotlib-3.10.0-cp311-cp311-win_amd64.whl",
-  "./wheels/matplotlib-3.10.0-cp311-cp311-macosx_11_0_arm64.whl",
-  "./wheels/matplotlib-3.10.0-cp311-cp311-macosx_10_12_x86_64.whl",
-  "./wheels/matplotlib-3.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-  "./wheels/pillow-11.1.0-cp311-cp311-macosx_10_10_x86_64.whl",
-  "./wheels/pillow-11.1.0-cp311-cp311-macosx_11_0_arm64.whl",
-  "./wheels/pillow-11.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-  "./wheels/pillow-11.1.0-cp311-cp311-win_amd64.whl",
-  "./wheels/contourpy-1.3.1-cp311-cp311-macosx_10_9_x86_64.whl",
-  "./wheels/contourpy-1.3.1-cp311-cp311-win_amd64.whl",
-  "./wheels/contourpy-1.3.1-cp311-cp311-macosx_11_0_arm64.whl",
-  "./wheels/contourpy-1.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-  "./wheels/kiwisolver-1.4.8-cp311-cp311-macosx_10_9_x86_64.whl",
-  "./wheels/kiwisolver-1.4.8-cp311-cp311-macosx_11_0_arm64.whl",
-  "./wheels/kiwisolver-1.4.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-  "./wheels/kiwisolver-1.4.8-cp311-cp311-win_amd64.whl",
+    "./wheels/contourpy-1.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    "./wheels/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl",
+    "./wheels/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl",
+    "./wheels/contourpy-1.3.3-cp313-cp313-win_amd64.whl",
+    "./wheels/cycler-0.12.1-py3-none-any.whl",
+    "./wheels/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl",
+    "./wheels/fonttools-4.62.1-cp313-cp313-macosx_10_13_x86_64.whl",
+    "./wheels/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+    "./wheels/fonttools-4.62.1-cp313-cp313-win_amd64.whl",
+    "./wheels/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl",
+    "./wheels/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl",
+    "./wheels/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+    "./wheels/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl",
+    "./wheels/matplotlib-3.10.8-cp313-cp313-macosx_10_13_x86_64.whl",
+    "./wheels/matplotlib-3.10.8-cp313-cp313-macosx_11_0_arm64.whl",
+    "./wheels/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+    "./wheels/matplotlib-3.10.8-cp313-cp313-win_amd64.whl",
+    "./wheels/networkx-3.6.1-py3-none-any.whl",
+    "./wheels/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    "./wheels/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl",
+    "./wheels/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl",
+    "./wheels/numpy-2.4.4-cp313-cp313-win_amd64.whl",
+    "./wheels/packaging-26.0-py3-none-any.whl",
+    "./wheels/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl",
+    "./wheels/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl",
+    "./wheels/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+    "./wheels/pillow-12.1.1-cp313-cp313-win_amd64.whl",
+    "./wheels/pyparsing-3.3.2-py3-none-any.whl",
+    "./wheels/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+    "./wheels/six-1.17.0-py2.py3-none-any.whl",
 ]
 
 [permissions]


### PR DESCRIPTION
Blender 5.1 updates python to 3.13 so this fix is intended to address that.

This does mean the minimum required version becomes 5.1, there might be a way around this but I haven't dug into seeing if it's possible.